### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A Model Context Protocol (MCP) server that enables AI assistants to interact wit
 
 Built by the [Diversio](https://diversio.com) team for streamlined AI-powered task management.
 
+<a href="https://glama.ai/mcp/servers/@DiversioTeam/clickup-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@DiversioTeam/clickup-mcp/badge" alt="ClickUp Server MCP server" />
+</a>
+
 ## 🚀 What This Server Provides
 
 ### ✅ Core Task Management


### PR DESCRIPTION
This PR adds a badge for the [ClickUp MCP Server](https://glama.ai/mcp/servers/@DiversioTeam/clickup-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@DiversioTeam/clickup-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@DiversioTeam/clickup-mcp/badge" alt="ClickUp Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.